### PR TITLE
Added some constraints for the SF Metroidvania Editor assembly

### DIFF
--- a/Editor/SF.MetroidvaniaToolkitEditor.asmdef
+++ b/Editor/SF.MetroidvaniaToolkitEditor.asmdef
@@ -1,0 +1,30 @@
+{
+    "name": "SF.MetroidvaniaToolkitEditor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:3a9781db4804a9945b9883f3a7c46d45",
+        "GUID:70643826bc633b246af1ece2db1e8338",
+        "GUID:e35e215503ab6b34eb8cadb39b7719da",
+        "GUID:5769175a692bee24cbd874f396613351",
+        "GUID:e8ca73d31c2608e498b77118a366f5dd"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "SF_UIELEMENTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "shatter-fantasy.sf-ui-elements",
+            "expression": "0.0.1",
+            "define": "SF_UIELEMENTS"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Editor/SF.MetroidvaniaToolkitEditor.asmdef.meta
+++ b/Editor/SF.MetroidvaniaToolkitEditor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 448f32118558a4c4684a361b65391c0e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This makes sure the SF UI Toolkit is installed before trying to compile the SF Metroidvania editor scripts relying on it.