### PR TITLE
Organized all runtime class namespaces and updated a lot of them for better clarity.

### DIFF
--- a/Editor/Data Editor/Inventory Editor/Toolbars/ItemDataToolbar.cs
+++ b/Editor/Data Editor/Inventory Editor/Toolbars/ItemDataToolbar.cs
@@ -1,4 +1,3 @@
-using SF.Inventory;
 using SF.ItemModule;
 
 using UnityEditor.UIElements;

--- a/Editor/Data Editor/Inventory Editor/Views/List Views/SFItemListView.cs
+++ b/Editor/Data Editor/Inventory Editor/Views/List Views/SFItemListView.cs
@@ -1,7 +1,6 @@
 using UnityEngine.UIElements;
 
 using SFEditor.Data;
-using SF.Inventory;
 using SF.ItemModule;
 using UnityEditor;
 using UnityEngine;

--- a/Runtime/Scripts/Abilities/AbilityController.cs
+++ b/Runtime/Scripts/Abilities/AbilityController.cs
@@ -1,13 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
-using SF.Characters.Controllers;
-using SF.PhysicsLowLevel;
 using UnityEngine;
 
 namespace SF.AbilityModule
 {
-    // Setting the default execution order past Controller2D.
-    // This guarantees the controller is already set up it's current physic struct in case any 
+    using SF.Characters.Controllers;
+    using PhysicsLowLevel;
     
     /// <summary>
     /// This is the <see cref="PlayerController"/> specific controller for abilities that only players use.

--- a/Runtime/Scripts/Abilities/AbilityCore.cs
+++ b/Runtime/Scripts/Abilities/AbilityCore.cs
@@ -1,11 +1,10 @@
 using UnityEngine;
 
-using SF.Characters;
-using SF.Managers;
-using SF.PhysicsLowLevel;
-
 namespace SF.AbilityModule
 {
+	using SF.Characters;
+	using Managers;
+	using PhysicsLowLevel;
 	/// <summary>
 	/// Abilities contain the data for what actions can do and how they do them.
 	/// </summary>

--- a/Runtime/Scripts/Abilities/Characters/Combat Abilities/NPCBasicAttackAbility.cs
+++ b/Runtime/Scripts/Abilities/Characters/Combat Abilities/NPCBasicAttackAbility.cs
@@ -1,9 +1,8 @@
-using SF.Weapons;
-
 using UnityEngine;
 
-namespace SF.AbilityModule.CombatModule
+namespace SF.AbilityModule
 {
+    using Weapons;
     public class NPCBasicAttackAbility : MonoBehaviour
     {
         [SerializeField] private WeaponBase _weaponBase;

--- a/Runtime/Scripts/Abilities/Characters/Combat Abilities/UseWeaponAbility.cs
+++ b/Runtime/Scripts/Abilities/Characters/Combat Abilities/UseWeaponAbility.cs
@@ -1,10 +1,11 @@
 using UnityEngine.InputSystem;
 
-using SF.InputModule;
-using SF.Weapons;
 
-namespace SF.AbilityModule.CombatModule
+namespace SF.AbilityModule
 {
+    using InputModule;
+    using Weapons;
+    
     public class UseWeaponAbility : AbilityCore, IInputAbility
     {
 

--- a/Runtime/Scripts/Abilities/Characters/Movement Abilities/ClimbAbility.cs
+++ b/Runtime/Scripts/Abilities/Characters/Movement Abilities/ClimbAbility.cs
@@ -1,11 +1,11 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-using SF.InputModule;
-using SF.PhysicsLowLevel;
-
 namespace SF.AbilityModule.Characters
 {
+    using InputModule;
+    using PhysicsLowLevel;
+    
     public class ClimbAbility : AbilityCore, IInputAbility
     {
         protected ClimbableSurface ClimableSurface => _controller2d.CollisionInfo.ClimbableSurface;

--- a/Runtime/Scripts/Abilities/Characters/Movement Abilities/CrouchAbility.cs
+++ b/Runtime/Scripts/Abilities/Characters/Movement Abilities/CrouchAbility.cs
@@ -1,10 +1,10 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-using SF.InputModule;
-
 namespace SF.AbilityModule.Characters
 {
+    using InputModule;
+    
     public class CrouchAbility : AbilityCore, IInputAbility
     {
         [SerializeField] private Vector2 _colliderResized = new Vector2(.5f,1.5f);

--- a/Runtime/Scripts/Abilities/Characters/Movement Abilities/GlideAbility.cs
+++ b/Runtime/Scripts/Abilities/Characters/Movement Abilities/GlideAbility.cs
@@ -1,11 +1,11 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-using SF.InputModule;
-using SF.PhysicsLowLevel;
-
 namespace SF.AbilityModule.Characters
 {
+    using InputModule;
+    using PhysicsLowLevel;
+    
     /// <summary>
     /// Grants the ability for a player to Glide with a set input command.
     /// Controller by an <see cref="AbilityController"/>.

--- a/Runtime/Scripts/Abilities/Characters/Movement Abilities/HorizontalMovementAbility.cs
+++ b/Runtime/Scripts/Abilities/Characters/Movement Abilities/HorizontalMovementAbility.cs
@@ -1,11 +1,10 @@
-using SF.Characters.Controllers;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using SF.InputModule;
-using SF.PhysicsLowLevel;
 
 namespace SF.AbilityModule.Characters
 {
+	using InputModule;
+	
     public class HorizontalMovementAbility : AbilityCore, IInputAbility
     {
         [SerializeField] private bool _isRunningToggleable = true;

--- a/Runtime/Scripts/Abilities/Characters/Movement Abilities/JumpAbility.cs
+++ b/Runtime/Scripts/Abilities/Characters/Movement Abilities/JumpAbility.cs
@@ -1,11 +1,12 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-using SF.InputModule;
-using SF.AudioModule;
+
 
 namespace SF.AbilityModule.Characters
 {
+    using InputModule;
+    
     public class JumpAbility : AbilityCore, IInputAbility
     {
         [Header("Jumping Physics")]

--- a/Runtime/Scripts/Abilities/Characters/Movement Abilities/JumpAbility.cs
+++ b/Runtime/Scripts/Abilities/Characters/Movement Abilities/JumpAbility.cs
@@ -1,8 +1,6 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-
-
 namespace SF.AbilityModule.Characters
 {
     using InputModule;

--- a/Runtime/Scripts/Abilities/Characters/Movement Abilities/JumpAbility.cs
+++ b/Runtime/Scripts/Abilities/Characters/Movement Abilities/JumpAbility.cs
@@ -4,7 +4,7 @@ using UnityEngine.InputSystem;
 namespace SF.AbilityModule.Characters
 {
     using InputModule;
-    
+    using AudioModule;
     public class JumpAbility : AbilityCore, IInputAbility
     {
         [Header("Jumping Physics")]

--- a/Runtime/Scripts/Attributes/Conditional/ConditionalShowAttribute.cs
+++ b/Runtime/Scripts/Attributes/Conditional/ConditionalShowAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
 
-namespace SF
+namespace SF.Core
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
     public class ConditionalShowAttribute : PropertyAttribute

--- a/Runtime/Scripts/Attributes/Types/TypeFilterAttribute.cs
+++ b/Runtime/Scripts/Attributes/Types/TypeFilterAttribute.cs
@@ -1,10 +1,7 @@
 using System;
-
-using Systems;
-
 using UnityEngine;
 
-namespace SF
+namespace SF.Core
 {
     public class TypeFilterAttribute : PropertyAttribute
     {

--- a/Runtime/Scripts/Characters/Controllers/ControllerBody2D.cs
+++ b/Runtime/Scripts/Characters/Controllers/ControllerBody2D.cs
@@ -1,8 +1,9 @@
-using SF.Characters;
 using UnityEngine;
 
 namespace SF.PhysicsLowLevel
 {
+    using Characters;
+    
     /// <summary>
     /// The base class for high performance physics controller that uses Unity's Low Level Physics2D system to allow for
     /// highly customizable physics that can even destroy, edit, and manipulate physics shapes in real time.

--- a/Runtime/Scripts/Characters/Controllers/PlayerController2D.cs
+++ b/Runtime/Scripts/Characters/Controllers/PlayerController2D.cs
@@ -1,8 +1,7 @@
-using SF.Managers;
-using SF.PhysicsLowLevel;
-
 namespace SF.Characters.Controllers
 {
+    using Managers;
+    using PhysicsLowLevel;
     /// <summary>
     /// A physics controller for the playable character that help implement gravity, slope mechanics, collision for platforms,
     /// and updates the <see cref="MovementState"/>.

--- a/Runtime/Scripts/CheckPoint/CheckPoint.cs
+++ b/Runtime/Scripts/CheckPoint/CheckPoint.cs
@@ -1,8 +1,8 @@
-using SF.DataManagement;
 using UnityEngine;
 
 namespace SF.SpawnModule
 {
+	using DataManagement;
     /// <summary>
     /// Sets the attached game object as a checkpoint for the loaded level and can be used to invoke a <see cref="CheckPointEventTypes.ChangeCheckPoint"/> event when an allowable object triggers an OnTriggerEnter2D callback on the attached object.
     /// </summary>

--- a/Runtime/Scripts/CommandNodes/Audio/SFXCommand.cs
+++ b/Runtime/Scripts/CommandNodes/Audio/SFXCommand.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 
-
 namespace SF.CommandModule
 {
     [System.Serializable]

--- a/Runtime/Scripts/CommandNodes/Camera/CinemachineCameraCommand.cs
+++ b/Runtime/Scripts/CommandNodes/Camera/CinemachineCameraCommand.cs
@@ -1,9 +1,10 @@
-using SF.CameraModule;
 using Unity.Cinemachine;
 using UnityEngine;
 
 namespace SF.CommandModule
 {
+    using CameraModule;
+    
     public enum CinemachineCommandTypes : ushort
     {
         SwitchPlayerCamera = 0,

--- a/Runtime/Scripts/CommandNodes/Characters/CharacterCommandNode.cs
+++ b/Runtime/Scripts/CommandNodes/Characters/CharacterCommandNode.cs
@@ -1,10 +1,10 @@
-using SF.Characters;
-using SF.Characters.Controllers;
-using SF.PhysicsLowLevel;
 using UnityEngine;
 
 namespace SF.CommandModule
 {
+    using Characters;
+    using PhysicsLowLevel;
+    
     public class CharacterCommandNode : CommandNode
     {
         [HideInInspector] public ControllerBody2D ControllerBody2D;

--- a/Runtime/Scripts/CommandNodes/CommandController.cs
+++ b/Runtime/Scripts/CommandNodes/CommandController.cs
@@ -1,13 +1,12 @@
 using System.Collections.Generic;
-
-using SF.Characters;
-using SF.Characters.Controllers;
-using SF.Managers;
-using SF.PhysicsLowLevel;
 using UnityEngine;
 
 namespace SF.CommandModule
 {
+    using Characters;
+    using Managers;
+    using PhysicsLowLevel;
+    
     public enum CommandType
     {
         Cutscene,

--- a/Runtime/Scripts/CommandNodes/Controllers/CharacterCommandController.cs
+++ b/Runtime/Scripts/CommandNodes/Controllers/CharacterCommandController.cs
@@ -1,9 +1,8 @@
-using SF.Characters;
-using SF.Characters.Controllers;
-using SF.PhysicsLowLevel;
-
 namespace SF.CommandModule
 {
+    using Characters;
+    using PhysicsLowLevel;
+    
     public class CharacterCommandController : CommandController
     {
         private ControllerBody2D _controller2d;

--- a/Runtime/Scripts/CommandNodes/Dialogue System/DialogueCommand.cs
+++ b/Runtime/Scripts/CommandNodes/Dialogue System/DialogueCommand.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using SF.DialogueModule;
 
 namespace SF.CommandModule
 {

--- a/Runtime/Scripts/CommandNodes/Status Effect/SetStatusEffectCommand.cs
+++ b/Runtime/Scripts/CommandNodes/Status Effect/SetStatusEffectCommand.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
-using SF.Characters;
 
 namespace SF.CommandModule
 {
+    using Characters;
     [System.Serializable]
     public class SetStatusEffectCommand : CharacterCommandNode
     {

--- a/Runtime/Scripts/CommandNodes/TransformCommand.cs
+++ b/Runtime/Scripts/CommandNodes/TransformCommand.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 namespace SF.CommandModule
 {
+    using SF.Core;
     [System.Serializable]
     [CommandMenu("Transform/Move")]
     public class TransformCommand : CommandNode

--- a/Runtime/Scripts/Common/MovementEnums.cs
+++ b/Runtime/Scripts/Common/MovementEnums.cs
@@ -1,4 +1,4 @@
-namespace SF
+namespace SF.Core
 {
     public enum MovementFollowType
     {

--- a/Runtime/Scripts/Damage/Damagables/CharacterHealth.cs
+++ b/Runtime/Scripts/Damage/Damagables/CharacterHealth.cs
@@ -1,11 +1,12 @@
 using System;
-using SF.Characters;
-using SF.CommandModule;
-using SF.PhysicsLowLevel;
 using UnityEngine;
 
 namespace SF.SpawnModule
 {
+    using Characters;
+    using CommandModule;
+    using PhysicsLowLevel;
+    
     /*  TODO: Merge this with the CombatantHealth.cs
         and remove this script from the package.    */
     

--- a/Runtime/Scripts/Damage/Damagables/CombatantHealth.cs
+++ b/Runtime/Scripts/Damage/Damagables/CombatantHealth.cs
@@ -2,7 +2,7 @@ namespace SF.SpawnModule
 {
     using Characters.Data;
     using Experience;
-    using SF.StateMachine.Core;
+    using StateMachine;
 
     public class CombatantHealth : CharacterHealth
     {

--- a/Runtime/Scripts/Damage/Damagables/CombatantHealth.cs
+++ b/Runtime/Scripts/Damage/Damagables/CombatantHealth.cs
@@ -1,9 +1,9 @@
-using SF.Characters.Data;
-using SF.Experience;
-using SF.StateMachine.Core;
-
 namespace SF.SpawnModule
 {
+    using Characters.Data;
+    using Experience;
+    using SF.StateMachine.Core;
+
     public class CombatantHealth : CharacterHealth
     {
         private CombatantData _combatantData;

--- a/Runtime/Scripts/Damage/Damagables/Health.cs
+++ b/Runtime/Scripts/Damage/Damagables/Health.cs
@@ -3,12 +3,10 @@ using System;
 using UnityEngine;
 using Unity.Properties;
 
-using SF.AudioModule;
-using SF.DamageModule;
-
-
 namespace SF.SpawnModule
 {
+    using AudioModule;
+    using DamageModule;
     /// <summary>
     /// Adds a health system to anything. 
     /// This does not need to be on a character. You can add this to a crate or anything that wants to be damaged. There are checks in do stuff for character specific objects if you want to.

--- a/Runtime/Scripts/Damage/Damagables/IDamageController.cs
+++ b/Runtime/Scripts/Damage/Damagables/IDamageController.cs
@@ -1,4 +1,3 @@
-
 namespace SF.DamageModule
 {
     /// <summary>

--- a/Runtime/Scripts/Damage/Damage Formulas/WeaponDamageBase.cs
+++ b/Runtime/Scripts/Damage/Damage Formulas/WeaponDamageBase.cs
@@ -1,7 +1,6 @@
-using SF.StatModule;
-
 namespace SF.DamageModule
 {
+    using StatModule;
     /// <summary>
     /// Used to calculate the damage a weapon should do to anything it is applying damage to.
     /// </summary>

--- a/Runtime/Scripts/Damage/Stomps/Stomp.cs
+++ b/Runtime/Scripts/Damage/Stomps/Stomp.cs
@@ -1,9 +1,8 @@
-using SF.DamageModule;
-using SF.PhysicsLowLevel;
 using UnityEngine;
 
-namespace SF
+namespace SF.DamageModule
 {
+    using PhysicsLowLevel;
     public class Stomp : MonoBehaviour
     {
         public float BounceVelocity = 5f;
@@ -15,6 +14,8 @@ namespace SF
             _collider2d = GetComponent<Collider2D>();
             _controller2D = GetComponent<ControllerBody2D>();
         }
+        
+        // TODO: Remove this. We don't use the old physics system anymore.
         public void OnTriggerEnter2D(Collider2D other)
         {
             if(other.TryGetComponent(out IStompable stompable))

--- a/Runtime/Scripts/Data Module/Character Data/CharacterDTO.cs
+++ b/Runtime/Scripts/Data Module/Character Data/CharacterDTO.cs
@@ -1,13 +1,13 @@
 using UnityEngine;
 
-using SF.DataModule;
-using SF.Experience;
-using SF.LootModule;
-using SF.StatModule;
-
-
 namespace SF.Characters.Data
 {
+    using DataModule;
+    using Experience;
+    using LootModule;
+    using StatModule;
+
+
     [CreateAssetMenu(fileName = "New Character Data", menuName = "SF/Data/Character Data")]
     public class CharacterDTO : DTOAssetBase
     {

--- a/Runtime/Scripts/Data Module/Character Data/CombatantData.cs
+++ b/Runtime/Scripts/Data Module/Character Data/CombatantData.cs
@@ -1,9 +1,9 @@
-using SF.LootModule;
-using SF.Experience;
 using UnityEngine;
 
 namespace SF.Characters.Data
 {
+    using LootModule;
+    using Experience;
     public class CombatantData : CharacterData
     {
         public LootTableData EnemyLootTable;

--- a/Runtime/Scripts/Data Module/DTOBase.cs
+++ b/Runtime/Scripts/Data Module/DTOBase.cs
@@ -1,4 +1,3 @@
-using SF.ItemModule;
 using UnityEngine;
 
 namespace SF.DataModule

--- a/Runtime/Scripts/Detection Module/DistanceDecision.cs
+++ b/Runtime/Scripts/Detection Module/DistanceDecision.cs
@@ -1,11 +1,11 @@
-using SF.SpawnModule;
-using SF.StateMachine.Core;
-
 using UnityEngine;
 using UnityEngine.Serialization;
 
 namespace SF.StateMachine.Decisions
 {
+    using SpawnModule;
+    using SF.StateMachine.Core;
+    
     public class DistanceDecision : StateDecisionCore
     {
         [FormerlySerializedAs("_distance")]

--- a/Runtime/Scripts/Detection Module/DistanceDecision.cs
+++ b/Runtime/Scripts/Detection Module/DistanceDecision.cs
@@ -4,7 +4,7 @@ using UnityEngine.Serialization;
 namespace SF.StateMachine.Decisions
 {
     using SpawnModule;
-    using SF.StateMachine.Core;
+    using StateMachine;
     
     public class DistanceDecision : StateDecisionCore
     {

--- a/Runtime/Scripts/Game Initializers/GameLoader.cs
+++ b/Runtime/Scripts/Game Initializers/GameLoader.cs
@@ -1,13 +1,13 @@
 using System;
-using SF.DataManagement;
-using SF.RoomModule;
-using SF.ItemModule;
-using SF.LevelModule;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace SF.Managers
 {
+    using DataManagement;
+    using RoomModule;
+    using ItemModule;
+    using LevelModule;
     /// <summary>
     /// Keeps track of the prefabs, scriptable objects that need loaded for first scene (think RoomDB), and makes sure all required
     /// Managers/Databases are ready before needing to be used.

--- a/Runtime/Scripts/Game Initializers/GameLoaderSO.cs
+++ b/Runtime/Scripts/Game Initializers/GameLoaderSO.cs
@@ -1,8 +1,8 @@
-using SF.RoomModule;
 using UnityEngine;
 
 namespace SF.Managers
 {
+    using RoomModule;
     public enum GameLoadingMode
     {
         NewGame, LoadGame, Continue

--- a/Runtime/Scripts/Handles/PositionHandle.cs
+++ b/Runtime/Scripts/Handles/PositionHandle.cs
@@ -1,4 +1,6 @@
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 
 namespace SF.HandleModule

--- a/Runtime/Scripts/Input/SFInputManager.cs
+++ b/Runtime/Scripts/Input/SFInputManager.cs
@@ -1,10 +1,11 @@
-using SF.AbilityModule;
-using SF.Managers;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
 namespace SF.InputModule
 {
+	using AbilityModule;
+	using Managers;
+	
     public class SFInputManager : MonoBehaviour
     {
 	    

--- a/Runtime/Scripts/Interactables/Activatables/IActivatable.cs
+++ b/Runtime/Scripts/Interactables/Activatables/IActivatable.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace SF
+namespace SF.Activatable
 {
     public interface IActivatable
     {

--- a/Runtime/Scripts/Interactables/Activatables/Platforms/ActivatablePlatform.cs
+++ b/Runtime/Scripts/Interactables/Activatables/Platforms/ActivatablePlatform.cs
@@ -1,12 +1,11 @@
-using SF.HandleModule;
-
 using UnityEngine;
 
-namespace SF
+namespace SF.Activatable
 {
-    [RequireComponent(typeof(PositionHandle))]
+    using HandleModule;
     
-    public class ActivatablePlatform : ActivatableWrapper, IActivatable
+    [RequireComponent(typeof(PositionHandle))]
+    public class ActivatablePlatform : ActivatableWrapper
     {
         [SerializeField] private float _speed = 5;
 

--- a/Runtime/Scripts/Interactables/Activatables/Unity Components/AnimationActivatable.cs
+++ b/Runtime/Scripts/Interactables/Activatables/Unity Components/AnimationActivatable.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
-
 using UnityEngine;
 
-namespace SF
+namespace SF.Activatable
 {
     public class AnimationActivatable : ActivatableWrapper, IActivatable
     {

--- a/Runtime/Scripts/Interactables/DialogueImprov.cs
+++ b/Runtime/Scripts/Interactables/DialogueImprov.cs
@@ -1,9 +1,9 @@
-using SF.Characters.Controllers;
-using SF.Interactables;
 using UnityEngine;
 
 namespace SF.DialogueModule
 {
+    using Characters.Controllers;
+    using Interactables;
     public class DialogueImprov : MonoBehaviour, IInteractable<PlayerController>
     {
         public int ConversationGUID;

--- a/Runtime/Scripts/Interactables/IInteractable.cs
+++ b/Runtime/Scripts/Interactables/IInteractable.cs
@@ -1,7 +1,6 @@
-using SF.Characters.Controllers;
-
 namespace SF.Interactables
 {
+	using Characters.Controllers;
 	public enum InteractableMode
 	{
 		Collision,

--- a/Runtime/Scripts/Interactables/Interactable Switches/InteractableSwitch.cs
+++ b/Runtime/Scripts/Interactables/Interactable Switches/InteractableSwitch.cs
@@ -1,13 +1,11 @@
 using System.Collections.Generic;
-
-using SF.Characters.Controllers;
-using SF.InputModule;
-using SF.Interactables;
-
 using UnityEngine;
 
-namespace SF
+namespace SF.Interactables
 {
+    using Characters.Controllers;
+    using InputModule;
+
     public class InteractableSwitch : MonoBehaviour, IInteractable
     {
 

--- a/Runtime/Scripts/Interactables/Interactable Switches/InteractableSwitch.cs
+++ b/Runtime/Scripts/Interactables/Interactable Switches/InteractableSwitch.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace SF.Interactables
 {
+    using Activatable;
     using Characters.Controllers;
     using InputModule;
 

--- a/Runtime/Scripts/Interactables/InteractionController.cs
+++ b/Runtime/Scripts/Interactables/InteractionController.cs
@@ -1,10 +1,10 @@
-using SF.PhysicsLowLevel;
 using Unity.Collections;
 using UnityEngine;
 using UnityEngine.LowLevelPhysics2D;
 
 namespace SF.Interactables
 {
+    using PhysicsLowLevel;
     public class InteractionController : MonoBehaviour
     {
         [SerializeField] protected PhysicsQuery.QueryFilter _interactableFilter;

--- a/Runtime/Scripts/Item System/Inventory/ItemContainer.cs
+++ b/Runtime/Scripts/Item System/Inventory/ItemContainer.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
-using SF.Managers;
 using UnityEngine;
 
 namespace SF.ItemModule
 {
+    using Managers;
     public class ItemContainer : MonoBehaviour
     {
         [SerializeReference]

--- a/Runtime/Scripts/Item System/Inventory/PlayerInventory.cs
+++ b/Runtime/Scripts/Item System/Inventory/PlayerInventory.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using SF.DataManagement;
-using SF.Managers;
 
 namespace SF.ItemModule
 {
+    using DataManagement;
+    using Managers;
     [Serializable]
     public class PlayerInventory : ItemContainer
     {

--- a/Runtime/Scripts/Item System/Item Database/Item DTOs/ItemDTO.cs
+++ b/Runtime/Scripts/Item System/Item Database/Item DTOs/ItemDTO.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
-using SF.DataModule;
 
 namespace SF.ItemModule
 {
+    using DataModule;
     /// <summary>
     /// The scriptable object data asset that makes keeps track of an item inside the item databases.
     /// </summary>

--- a/Runtime/Scripts/Item System/Items/Item Types/ItemEnums.cs
+++ b/Runtime/Scripts/Item System/Items/Item Types/ItemEnums.cs
@@ -1,8 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-namespace SF
+namespace SF.ItemModule
 {
 	public enum WeaponType
 	{

--- a/Runtime/Scripts/Item System/Items/Item Types/Weapon.cs
+++ b/Runtime/Scripts/Item System/Items/Item Types/Weapon.cs
@@ -1,6 +1,3 @@
-using SF.Inventory;
-using UnityEngine;
-
 namespace SF.ItemModule
 {
 	[System.Serializable]

--- a/Runtime/Scripts/Item System/Items/ItemData.cs
+++ b/Runtime/Scripts/Item System/Items/ItemData.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using SF.Inventory;
-using UnityEngine;
-
 namespace SF.ItemModule
 {
     /// <summary>

--- a/Runtime/Scripts/Level Managment/LevelLoader.cs
+++ b/Runtime/Scripts/Level Managment/LevelLoader.cs
@@ -1,12 +1,10 @@
 using System;
-using SF.CameraModule;
-using SF.RoomModule;
-using SF.SpawnModule;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace SF.LevelModule
 {
+    using RoomModule;
     /// <summary>
     /// Loads the required game objects for used in managers and core systems in playable levels.
     /// </summary>

--- a/Runtime/Scripts/Managers/GameManager.cs
+++ b/Runtime/Scripts/Managers/GameManager.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using SF.DataManagement;
-using SF.DialogueModule;
-using SF.Settings;
 using UnityEngine;
 
 namespace SF.Managers
 {
+    using DataManagement;
+    using DialogueModule;
+    using Settings;
 	/// <summary>
 	/// The current state that is controlling the games input and actions. 
 	/// </summary>

--- a/Runtime/Scripts/Net Code/CollectionsMarshal.cs
+++ b/Runtime/Scripts/Net Code/CollectionsMarshal.cs
@@ -1,7 +1,5 @@
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
-using UnityEngine.UIElements;
-using System.Diagnostics;
 
 namespace System.Runtime.InteropServices
 {
@@ -10,8 +8,7 @@ namespace System.Runtime.InteropServices
     /* DON"T TOUCH THIS FILE OR THE WORLD WILL BE DESTROYED.*/
 
     /* This entire file brings .net 9 and CoreCLR stuff not normally in Unity into the version of .net that Unity uses.*/
-
-
+    
     /// <summary>
     /// Used internally to control behavior of insertion into a <see cref="Dictionary{TKey, TValue}"/> or <see cref="HashSet{T}"/>.
     /// </summary>

--- a/Runtime/Scripts/Pathfinding/Heap.cs
+++ b/Runtime/Scripts/Pathfinding/Heap.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SF.Core
+namespace SF
 {
     public interface IHeapItem<TItemData> : IComparable<TItemData>
     {

--- a/Runtime/Scripts/Pathfinding/Heap.cs
+++ b/Runtime/Scripts/Pathfinding/Heap.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SF
+namespace SF.Core
 {
     public interface IHeapItem<TItemData> : IComparable<TItemData>
     {

--- a/Runtime/Scripts/Pathfinding/PathNodes/PathNodeBase.cs
+++ b/Runtime/Scripts/Pathfinding/PathNodes/PathNodeBase.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace SF.Pathfinding
 {
+    using SF.Core;
     [Serializable]
     public class PathNodeBase : IHeapItem<PathNodeBase>
     {

--- a/Runtime/Scripts/Pathfinding/PathRequetManager.cs
+++ b/Runtime/Scripts/Pathfinding/PathRequetManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 using UnityEngine;

--- a/Runtime/Scripts/Pathfinding/Pathfinding/PathAStar.cs
+++ b/Runtime/Scripts/Pathfinding/Pathfinding/PathAStar.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-
 using UnityEngine;
 
 namespace SF.Pathfinding

--- a/Runtime/Scripts/Physics/Collision/CollisionInfoBase.cs
+++ b/Runtime/Scripts/Physics/Collision/CollisionInfoBase.cs
@@ -1,5 +1,4 @@
 using System;
-using SF.Characters.Controllers;
 using UnityEngine;
 
 namespace SF.PhysicsLowLevel

--- a/Runtime/Scripts/Projectile/IProjectile.cs
+++ b/Runtime/Scripts/Projectile/IProjectile.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace SF.ProjectileModule
+namespace SF.Weapons.ProjectileModule
 {
     public interface IProjectile
     {

--- a/Runtime/Scripts/Projectile/Projectile.cs
+++ b/Runtime/Scripts/Projectile/Projectile.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace SF.ProjectileModule
+namespace SF.Weapons.ProjectileModule
 {
     public class Projectile : MonoBehaviour, IProjectile
     {

--- a/Runtime/Scripts/Room Module/Room Extensions/IRoomExtension.cs
+++ b/Runtime/Scripts/Room Module/Room Extensions/IRoomExtension.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 namespace SF.RoomModule
 {
     /// <summary>

--- a/Runtime/Scripts/Room Module/RoomCharacterSpawner.cs
+++ b/Runtime/Scripts/Room Module/RoomCharacterSpawner.cs
@@ -1,6 +1,3 @@
-using SF.Characters.Data;
-using SF.RoomModule;
-using SF.StatModule;
 using UnityEngine;
 
 #if UNITY_EDITOR
@@ -9,6 +6,9 @@ using UnityEngine;
 
 namespace SF.SpawnModule
 {
+    using Characters.Data;
+    using RoomModule;
+    using StatModule;
     [System.Serializable]
     public struct SpawnSet
     {

--- a/Runtime/Scripts/Room Module/RoomSystem.cs
+++ b/Runtime/Scripts/Room Module/RoomSystem.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using SF.CameraModule;
-using SF.Managers;
 using UnityEngine;
 using Object = UnityEngine.Object;
 

--- a/Runtime/Scripts/Save System/MetroidvaniaSaveData.cs
+++ b/Runtime/Scripts/Save System/MetroidvaniaSaveData.cs
@@ -1,9 +1,9 @@
-using SF.ItemModule;
-using SF.SpawnModule;
-using SF.StatModule;
-
 namespace SF.DataManagement
 {
+    using ItemModule;
+    using SpawnModule;
+    using StatModule;
+
     [System.Serializable]
     public class MetroidvaniaSaveData : SaveDataBlock
     {

--- a/Runtime/Scripts/Save System/MetroidvaniaSaveManager.cs
+++ b/Runtime/Scripts/Save System/MetroidvaniaSaveManager.cs
@@ -1,9 +1,9 @@
-using SF.ItemModule;
-using SF.RoomModule;
-using SF.SpawnModule;
-
 namespace SF.DataManagement
 {
+    using ItemModule;
+    using RoomModule;
+    using SpawnModule;
+
     public class MetroidvaniaSaveManager : SaveSystem
     {
         /// <summary>

--- a/Runtime/Scripts/Save System/MetroidvaniaSaveStation.cs
+++ b/Runtime/Scripts/Save System/MetroidvaniaSaveStation.cs
@@ -1,11 +1,9 @@
-using SF.Characters.Controllers;
-using SF.RoomModule;
-using SF.SpawnModule;
-using SF.StatModule;
-using UnityEngine;
-
 namespace SF.DataManagement
 {
+    using Characters.Controllers;
+    using RoomModule;
+    using SpawnModule;
+    using StatModule;
     public class MetroidvaniaSaveStation : SaveStation
     {
         

--- a/Runtime/Scripts/Save System/SavePoint.cs
+++ b/Runtime/Scripts/Save System/SavePoint.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace SF.DataManagement
 {
-    public class SavePoint : MonoBehaviour
+    public abstract class SavePoint : MonoBehaviour
     {
         protected virtual void Save()
         {

--- a/Runtime/Scripts/Save System/SaveStation.cs
+++ b/Runtime/Scripts/Save System/SaveStation.cs
@@ -1,12 +1,12 @@
-using SF.Characters.Controllers;
-using SF.Interactables;
-using SF.RoomModule;
-using SF.SpawnModule;
-using SF.StatModule;
 using UnityEngine;
 
 namespace SF.DataManagement
 {
+    using Characters.Controllers;
+    using Interactables;
+    using RoomModule;
+    using SpawnModule;
+    using StatModule;
     
     public class SaveStation : CheckPoint, IInteractable<PlayerController>
     {

--- a/Runtime/Scripts/Save System/SaveSystem.cs
+++ b/Runtime/Scripts/Save System/SaveSystem.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+#if !UNITY_EDITOR
+using System.Security.Cryptography;
+#endif
 using UnityEngine;
 using UnityEngine.SceneManagement;
 

--- a/Runtime/Scripts/Save System/SaveSystem.cs
+++ b/Runtime/Scripts/Save System/SaveSystem.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 
 using UnityEngine;
 using UnityEngine.SceneManagement;

--- a/Runtime/Scripts/Spawn Module/SpawnSystem.cs
+++ b/Runtime/Scripts/Spawn Module/SpawnSystem.cs
@@ -1,11 +1,11 @@
 using System;
-using SF.Characters.Controllers;
-using SF.PhysicsLowLevel;
-using SF.RoomModule;
 using UnityEngine;
 
 namespace SF.SpawnModule
 {
+    using Characters.Controllers;
+    using PhysicsLowLevel;
+    using RoomModule;
     /// <summary>
     /// The system that controls the logic for spawning the player. 
     /// </summary>

--- a/Runtime/Scripts/Spawn Module/TimedCharacterSpawner.cs
+++ b/Runtime/Scripts/Spawn Module/TimedCharacterSpawner.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using Random = UnityEngine.Random;
 

--- a/Runtime/Scripts/Stat Module/Charactes Stats/CharacterStats.cs
+++ b/Runtime/Scripts/Stat Module/Charactes Stats/CharacterStats.cs
@@ -1,13 +1,11 @@
-using SF.DamageModule;
-using SF.SpawnModule;
-
 using UnityEngine;
-
-using SF.Experience;
 using Unity.Properties;
 
 namespace SF.StatModule
 {
+    using DamageModule;
+    using SpawnModule;
+
     /// <summary>
     /// Links the character stats from the database to an actual gameobject. Also controls stat events for external components relying on character data. Example linking HP stat to a health controller script.
     /// </summary>

--- a/Runtime/Scripts/Stat Module/Charactes Stats/PlayerStats.cs
+++ b/Runtime/Scripts/Stat Module/Charactes Stats/PlayerStats.cs
@@ -1,7 +1,7 @@
-using SF.Experience;
-
 namespace SF.StatModule
 {
+    using Experience;
+
     public class PlayerStats : CharacterStats
     {
         public PlayerLevelStats PlayerLevelStats;

--- a/Runtime/Scripts/Stat Module/Core/StatDatabase.cs
+++ b/Runtime/Scripts/Stat Module/Core/StatDatabase.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using UnityEngine;
-using SF.Inventory.StatModule;
 
 namespace SF.StatModule
 {
+    using SF.Inventory.StatModule;
     /// <summary>
     /// The default set stat for different type of objects that will be using any stat sets.
     /// </summary>

--- a/Runtime/Scripts/Stat Module/Core/StatDatabase.cs
+++ b/Runtime/Scripts/Stat Module/Core/StatDatabase.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 
 namespace SF.StatModule
 {
-    using SF.Inventory.StatModule;
     /// <summary>
     /// The default set stat for different type of objects that will be using any stat sets.
     /// </summary>

--- a/Runtime/Scripts/Stat Module/Core/StatList.cs
+++ b/Runtime/Scripts/Stat Module/Core/StatList.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 
-using SF.Inventory.StatModule;
-
 namespace SF.StatModule
 {
 

--- a/Runtime/Scripts/Stat Module/Core/StatMediator.cs
+++ b/Runtime/Scripts/Stat Module/Core/StatMediator.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-using SF.Inventory.StatModule;
-
 namespace SF.StatModule
 {
     public enum StatValueRoundingType

--- a/Runtime/Scripts/Stat Module/Item Stats/ElementalAttributeStat.cs
+++ b/Runtime/Scripts/Stat Module/Item Stats/ElementalAttributeStat.cs
@@ -1,10 +1,6 @@
-using System;
-using UnityEngine;
-using SF.StatModule;
-
-namespace SF.Inventory.StatModule
+namespace SF.StatModule
 {
-    [Flags]
+    [System.Flags]
     public enum ElementalType : uint
     {
         None = 0,

--- a/Runtime/Scripts/Stat Module/Item Stats/PriceStat.cs
+++ b/Runtime/Scripts/Stat Module/Item Stats/PriceStat.cs
@@ -1,7 +1,4 @@
-using UnityEngine;
-using SF.StatModule;
-
-namespace SF.Inventory.StatModule
+namespace SF.StatModule
 {
     /// <summary>
     /// The pricing stat is used for making different things adjust the pricing value of items.

--- a/Runtime/Scripts/Stat Module/Utilities/StatExtensions.cs
+++ b/Runtime/Scripts/Stat Module/Utilities/StatExtensions.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 
-using SF.Inventory.StatModule;
-
 namespace SF.StatModule
 {
     public static class StatExtensions

--- a/Runtime/Scripts/State Machine/AI/AI States/ChaseAIState.cs
+++ b/Runtime/Scripts/State Machine/AI/AI States/ChaseAIState.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 
 namespace SF.StateMachine
 {
-    using StateMachine.Core;
     using SpawnModule;
     public class ChaseAIState : StateCore
     {

--- a/Runtime/Scripts/State Machine/AI/AI States/ChaseAIState.cs
+++ b/Runtime/Scripts/State Machine/AI/AI States/ChaseAIState.cs
@@ -1,14 +1,9 @@
-using SF.Characters.Controllers;
-using SF.LevelModule;
-using SF.Managers;
-using SF.PhysicsLowLevel;
-using SF.SpawnModule;
 using UnityEngine;
-
-using SF.StateMachine.Core;
 
 namespace SF.StateMachine
 {
+    using StateMachine.Core;
+    using SpawnModule;
     public class ChaseAIState : StateCore
     {
         [SerializeField] private bool _chasePlayer;

--- a/Runtime/Scripts/State Machine/AI/AI States/PathfindingAIState.cs
+++ b/Runtime/Scripts/State Machine/AI/AI States/PathfindingAIState.cs
@@ -1,13 +1,13 @@
 using System;
-using SF.Pathfinding;
-using SF.PhysicsLowLevel;
-using SF.SpawnModule;
-using SF.StateMachine.Decisions;
 using UnityEngine;
 using UnityEngine.LowLevelPhysics2D;
 
-namespace SF.StateMachine.Core
+namespace SF.StateMachine
 {
+	using Pathfinding;
+	using PhysicsLowLevel;
+	using SpawnModule;
+	using StateMachine.Decisions;
     public class PathfindingAIState : StateCore
     {
 	    [SerializeField] private float _speed = 5;

--- a/Runtime/Scripts/State Machine/AI/AI States/PatrolAIState.cs
+++ b/Runtime/Scripts/State Machine/AI/AI States/PatrolAIState.cs
@@ -1,10 +1,10 @@
-using SF.PhysicsLowLevel;
-using SF.StateMachine.Core;
-
 using UnityEngine;
 
 namespace SF.StateMachine
 {
+	using PhysicsLowLevel;
+	using SF.StateMachine.Core;
+
     public class PatrolAIState : StateCore
     {
         public bool StartingRight = true;

--- a/Runtime/Scripts/State Machine/AI/AI States/PatrolAIState.cs
+++ b/Runtime/Scripts/State Machine/AI/AI States/PatrolAIState.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 namespace SF.StateMachine
 {
 	using PhysicsLowLevel;
-	using SF.StateMachine.Core;
 
     public class PatrolAIState : StateCore
     {

--- a/Runtime/Scripts/State Machine/AI/AI States/SingleAttackState.cs
+++ b/Runtime/Scripts/State Machine/AI/AI States/SingleAttackState.cs
@@ -1,11 +1,9 @@
-using SF.Characters.Controllers;
-using SF.PhysicsLowLevel;
-using SF.StateMachine.Core;
-using SF.Weapons;
 using UnityEngine;
 
 namespace SF.StateMachine
 {
+    using PhysicsLowLevel;
+    using Weapons;
     public class SingleAttackState : StateCore
     {
 

--- a/Runtime/Scripts/State Machine/Core/IState.cs
+++ b/Runtime/Scripts/State Machine/Core/IState.cs
@@ -1,4 +1,4 @@
-namespace SF.StateMachine.Core
+namespace SF.StateMachine
 {
 	public interface IState
     {

--- a/Runtime/Scripts/State Machine/Core/StateCore.cs
+++ b/Runtime/Scripts/State Machine/Core/StateCore.cs
@@ -1,14 +1,13 @@
 using System.Collections.Generic;
 using System.Linq;
-using SF.Characters;
-using SF.Characters.Controllers;
-using SF.PhysicsLowLevel;
-using SF.StateMachine.Decisions;
 
 using UnityEngine;
 
 namespace SF.StateMachine.Core
 {
+	using Characters;
+	using PhysicsLowLevel;
+	using Decisions;
 	public class DecisionTransition
 	{
 		public bool CanTransist;

--- a/Runtime/Scripts/State Machine/Core/StateCore.cs
+++ b/Runtime/Scripts/State Machine/Core/StateCore.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 using UnityEngine;
 
-namespace SF.StateMachine.Core
+namespace SF.StateMachine
 {
 	using Characters;
 	using PhysicsLowLevel;

--- a/Runtime/Scripts/State Machine/Core/StateDecisionCore.cs
+++ b/Runtime/Scripts/State Machine/Core/StateDecisionCore.cs
@@ -3,8 +3,6 @@ using UnityEngine;
 
 namespace SF.StateMachine.Decisions
 {
-    using Core;
-
     /// <summary>
     /// Transitions are the classes that control the logic for when a state should change to another state.
     /// </summary>

--- a/Runtime/Scripts/State Machine/Core/StateMachineBrain.cs
+++ b/Runtime/Scripts/State Machine/Core/StateMachineBrain.cs
@@ -1,13 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using SF.Characters.Controllers;
-using SF.PhysicsLowLevel;
 using UnityEngine;
 
 namespace SF.StateMachine.Core
 {
-	
+	using PhysicsLowLevel;
 	/// <summary>
 	/// This is for controlling non-player controlled characters states and actions.
 	/// 

--- a/Runtime/Scripts/State Machine/Core/StateMachineBrain.cs
+++ b/Runtime/Scripts/State Machine/Core/StateMachineBrain.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
-
 using UnityEngine;
 
-namespace SF.StateMachine.Core
+namespace SF.StateMachine
 {
 	using PhysicsLowLevel;
 	/// <summary>

--- a/Runtime/Scripts/Transition System/Core Transitions/ICameraTransition.cs
+++ b/Runtime/Scripts/Transition System/Core Transitions/ICameraTransition.cs
@@ -1,5 +1,3 @@
-using Unity.Cinemachine;
-
 namespace SF.Transitions
 {
     public interface ICameraTransition : ITransition

--- a/Runtime/Scripts/Transition System/TransitionSystem.cs
+++ b/Runtime/Scripts/Transition System/TransitionSystem.cs
@@ -1,10 +1,6 @@
-using SF.Characters.Controllers;
-using SF.Managers;
-using SF.RoomModule;
-using UnityEngine;
-
 namespace SF.Transitions
 {
+    using RoomModule;
     /// <summary> Includes telling the <see cref="RoomSystem"/> to load/deload the rooms involved in the transition.
     /// </summary>
     public static class TransitionSystem

--- a/Runtime/Scripts/UI Overlay/UIOverlayView.cs
+++ b/Runtime/Scripts/UI Overlay/UIOverlayView.cs
@@ -1,9 +1,9 @@
-using SF.ItemModule;
 using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace SF.UIModule
 {
+    using ItemModule;
     public class UIOverlayView : MonoBehaviour
     {
         [SerializeField] private UIDocument _overlayUXML;

--- a/Runtime/Scripts/Utilities/2D Utilities/SpriteUtilities.cs
+++ b/Runtime/Scripts/Utilities/2D Utilities/SpriteUtilities.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace SF.Utilities
+namespace SF.Sprite
 {
     public static class SpriteUtilities
     {

--- a/Runtime/Scripts/Utilities/2D Utilities/SpriteUtilities.cs
+++ b/Runtime/Scripts/Utilities/2D Utilities/SpriteUtilities.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace SF.Sprite
+namespace SF.U2D
 {
     public static class SpriteUtilities
     {

--- a/Runtime/Scripts/Utilities/Bounds/BoundsData.cs
+++ b/Runtime/Scripts/Utilities/Bounds/BoundsData.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 
 namespace SF.PhysicsLowLevel
 {
+	
+	//TODO: Remove. The PhysicsShape and PhysicsBody.aabb replaces this.
 	[System.Serializable]
 	public struct BoundsData
 	{

--- a/Runtime/Scripts/Utilities/Extensions/TypeExtensions.cs
+++ b/Runtime/Scripts/Utilities/Extensions/TypeExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace Systems
+namespace SF.Core
 {
     public static class TypeExtensions 
     {

--- a/Runtime/Scripts/Utilities/Logging/LoggingSystem.cs
+++ b/Runtime/Scripts/Utilities/Logging/LoggingSystem.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
-namespace SF
+namespace SF.LoggingModule
 {
 	public static class LoggingSystem 
 	{

--- a/Runtime/Scripts/Utilities/Math/BoundExtensions.cs
+++ b/Runtime/Scripts/Utilities/Math/BoundExtensions.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace SF.Platformer.Utilities
+namespace SF.Math
 {
 #if !SF_Utilities
     /// <summary>

--- a/Runtime/Scripts/Utilities/Math/BoundExtensions.cs
+++ b/Runtime/Scripts/Utilities/Math/BoundExtensions.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace SF.Math
+namespace SF
 {
 #if !SF_Utilities
     /// <summary>

--- a/Runtime/Scripts/Utilities/Timing/AbilityCooldown.cs
+++ b/Runtime/Scripts/Utilities/Timing/AbilityCooldown.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 namespace SF.AbilityModule
 {
     /// <summary>

--- a/Runtime/Scripts/Utilities/Timing/ITimer.cs
+++ b/Runtime/Scripts/Utilities/Timing/ITimer.cs
@@ -1,9 +1,6 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-namespace SF
+namespace SF.Core
 {
+    // TODO: Remove. Replaced by the base class called Timer.
         public interface ITimer 
         {
             public void StartTimer() {}

--- a/Runtime/Scripts/Weapons/Melee Weapons/ComboMeleeWeapon.cs
+++ b/Runtime/Scripts/Weapons/Melee Weapons/ComboMeleeWeapon.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Runtime/Scripts/Weapons/Melee Weapons/ComboMeleeWeapon.cs
+++ b/Runtime/Scripts/Weapons/Melee Weapons/ComboMeleeWeapon.cs
@@ -1,10 +1,10 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace SF.Weapons
 {
     using CombatModule;
-    
     public class ComboMeleeWeapon : MeleeWeapon
     {
         [Header("Combo Properties")]

--- a/Runtime/Scripts/Weapons/Melee Weapons/MeleeWeapon.cs
+++ b/Runtime/Scripts/Weapons/Melee Weapons/MeleeWeapon.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 using UnityEngine;

--- a/Runtime/Scripts/Weapons/Melee Weapons/MeleeWeapon.cs
+++ b/Runtime/Scripts/Weapons/Melee Weapons/MeleeWeapon.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using UnityEngine;

--- a/Runtime/Scripts/Weapons/ProjectileWeapon.cs
+++ b/Runtime/Scripts/Weapons/ProjectileWeapon.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-using SF.ProjectileModule;
-
-
 namespace SF.Weapons
 {
+    using ProjectileModule;
     public class ProjectileWeapon : MonoBehaviour, IWeapon
     {
         [SerializeField] private bool _isAutoFire = false;

--- a/Runtime/Scripts/Weapons/WeaponBase.cs
+++ b/Runtime/Scripts/Weapons/WeaponBase.cs
@@ -1,12 +1,9 @@
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.LowLevelPhysics2D;
-using UnityEngine.Serialization;
 
 namespace SF.Weapons
 {
     using Characters;
-    using CombatModule;
     using PhysicsLowLevel;
     
     public enum AttackState


### PR DESCRIPTION
Updated: Following changes are for the SF Metroidvania Toolkit main runtime assembly.
- All using statements for SF related namespaces were made as nested namespaces in the file.
- Removed some extra namespaces that are no longer needed.

- Merged some namespace together.
Example
Merged SF.StateMachine.Core into just SF.StateMachine.

- Added some namespaces as nested ones
Example 
SF.ProjectileModule became SF.Weapons.ProjectileModule

- Fixed some namespaces acidentally in the SF namespace and not the respected category.
Example
ItemEnums was in just the SF namespace not the namespace for SF.ItemModule.